### PR TITLE
fix(ospo): rename national-digital-twin to national-node-net

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+<!--
+ Before you open a pull request please review the following guidelines and tip and edit the relevant sections.
+ Thank you for contributing! 
+ -->
+
+### Type of Change
+
+<!-- Select - i.e. 
+  - new feature
+  - bug fix
+-->
+
+### Description 
+
+<!-- Describe the scope of your change - i.e. 
+  - what the change does how it was tested 
+  - any known limitations
+  - any tests or examples exercised on your modified code
+-->
+
+### Checklist
+
+<!-- [Place an '[X]' (no spaces) in all applicable fields. Please add/remove fields as required.] -->
+
+- [ ] Test code against a test environment and not just on a local cluster 
+- [ ] Reference relevant issue(s) where applicable and close them after merging
+- [ ] Update any documentation and relevant `CHANGELOG.md` files

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,9 +24,9 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "16:00"
-      target-branch: develop
       commit-message:
         prefix: "chore(deps)"
+    target-branch: develop
     groups:
       sorbet:
         patterns:
@@ -56,6 +56,7 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "16:00"
+    target-branch: develop
     groups:
       prod-dependencies:
         dependency-type: "production"
@@ -73,6 +74,7 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "16:00"
+    target-branch: develop
   - package-ecosystem: "docker"
     directories:
       - "/"
@@ -82,12 +84,14 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "16:00"
+    target-branch: develop
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "sunday"
       time: "16:00"
+    target-branch: develop
     groups:
       all-actions:
         patterns: [ "*" ]
@@ -97,18 +101,21 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "16:00"
+    target-branch: develop
   - package-ecosystem: "mix"
     directory: "/hex/helpers"
     schedule:
       interval: "weekly"
       day: "sunday"
       time: "16:00"
+    target-branch: develop
   - package-ecosystem: "npm"
     directory: "/npm_and_yarn/helpers"
     schedule:
       interval: "weekly"
       day: "sunday"
       time: "16:00"
+    target-branch: develop
     groups:
       npm-dependencies:
         patterns:
@@ -139,6 +146,7 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "16:00"
+    target-branch: develop
     groups:
       common:
         patterns:
@@ -167,21 +175,25 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "16:00"
+    target-branch: develop
   - package-ecosystem: "nuget"
     directory: "/nuget/helpers/lib/NuGetUpdater"
     schedule:
       interval: "weekly"
       day: "sunday"
       time: "16:00"
+    target-branch: develop
   - package-ecosystem: "dotnet-sdk"
     directory: "/nuget/helpers/lib/NuGetUpdater"
     schedule:
       interval: "weekly"
       day: "sunday"
       time: "16:00"
+    target-branch: develop
   - package-ecosystem: "gitsubmodule"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "sunday"
       time: "16:00"
+    target-branch: develop

--- a/.github/workflows/auto-back-merge.yml
+++ b/.github/workflows/auto-back-merge.yml
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: Apache-2.0
+# © Crown Copyright 2026. This work has been developed by the National Digital Twin Programme and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
+
+# This workflow is triggered when a pull request is merged into the main branch and automatically merges the main branch back into develop to keep it up to date.
+# If the merge fails (e.g., due to conflicts), a manual intervention is required. The workflow generates a Job summary of the merge attempt.
+name: Auto Back-merge Main to Develop
+
+on:
+  pull_request:
+    types: 
+      - closed
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  merge-main-to-develop:
+
+    permissions: {}
+
+    name: Back-merge Main to Develop
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Generate Sync Token
+        id: sync-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.NODE_NET_REPOSITORY_WRITER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.NODE_NET_REPOSITORY_WRITER_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-workflows: write
+
+      - name: Merge main into develop and Generate Summary
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ steps.sync-token.outputs.token }}
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const mergedBy = context.payload.sender.login;
+            const prUrl = context.payload.pull_request.html_url;
+
+            try {
+              // Attempt to merge main into develop, use the api to ensure the commit
+              // is gpg signed.
+              await github.rest.repos.merge({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                base: 'develop',
+                head: 'main',
+                commit_message: `Merge branch 'main' into 'develop' (#${prNumber})`
+              });
+
+              let summaryText =
+              `## Sync Main to Develop ✅
+
+              Successfully triggered a merge of \`main\` into \`develop\` following the closure of PR #${prNumber}.
+
+              **Original PR Merged by**: @${mergedBy}
+
+              [View Original PR](${prUrl})
+              `;
+
+              await core.summary.addRaw(summaryText).write();
+            } catch (error) {
+              const finalErrorMessage = error.message || error;
+              // Write failure summary
+              summaryText =
+              `## Sync Main to Develop ❌
+
+              Failed to trigger a merge of \`main\` into \`develop\`! This is usually due to a merge conflict. Please resolve it manually by opening a PR from \`main\` to \`develop\`.
+
+              ### Error Details:
+
+              \`\`\`text
+              ${finalErrorMessage}
+              \`\`\`
+
+              **Original PR Merged by**: @${mergedBy}
+
+              [View Original PR](${prUrl})
+              `;
+
+              await core.summary.addRaw(summaryText).write();
+
+              // Fail the workflow step
+              core.setFailed(`Merge failed: ${finalErrorMessage}`);
+            }

--- a/.github/workflows/build-compose-action.yml
+++ b/.github/workflows/build-compose-action.yml
@@ -82,7 +82,7 @@ jobs:
 
   build-tag-push:
     needs: build-maven
-    uses: National-Digital-Twin/aws-integration-testing/.github/workflows/build-tag-push-docker-image-to-ecr.yml@main
+    uses: National-Node-Net/aws-integration-testing/.github/workflows/build-tag-push-docker-image-to-ecr.yml@main
     with:
         image_tag: ${{needs.build-maven.outputs.PROJECT_VERSION}}-${{github.sha}}
         container_repo: 'secure-agent-graph'
@@ -92,14 +92,14 @@ jobs:
 
   copy-config-files:
     needs: build-maven
-    uses: National-Digital-Twin/aws-integration-testing/.github/workflows/copy-files-to-ec2-instance.yml@main
+    uses: National-Node-Net/aws-integration-testing/.github/workflows/copy-files-to-ec2-instance.yml@main
     with:
       directory_name: 'sag-docker/mnt'
     secrets: inherit
 
   docker-compose-up:
     needs: [copy-config-files, build-tag-push]
-    uses: National-Digital-Twin/aws-integration-testing/.github/workflows/docker-compose-up.yml@main
+    uses: National-Node-Net/aws-integration-testing/.github/workflows/docker-compose-up.yml@main
     with:
       docker-compose-file-name: 'docker-compose-github.yaml'
     secrets: inherit

--- a/.github/workflows/oss-checker.yml
+++ b/.github/workflows/oss-checker.yml
@@ -1,0 +1,564 @@
+# SPDX-License-Identifier: Apache-2.0
+# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
+
+name: Run OSS check helper
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+  workflow_dispatch:
+
+jobs:
+  oss-checks:
+    permissions:
+      contents: read
+    if: github.actor != 'dependabot[bot]' &&
+      (github.event.repository.private == false ||
+      (github.event.repository.private == true &&
+      contains(join(github.event.pull_request.labels.*.name), 'oss-preparation')))
+    runs-on: ubuntu-latest
+    outputs:
+      summary-table: ${{ steps.summarise_results.outputs.summaryTable }}
+      has-results: ${{ steps.summarise_results.outputs.hasResults }}
+
+    steps:
+      - name: Fetch GitHub App token for target repo
+        id: target_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.OSPO_WORKFLOW_APP_ID }}
+          private-key: ${{ secrets.OSPO_WORKFLOW_PRIVATE_KEY }}
+          permission-contents: read
+
+      - name: Fetch GitHub App token for OSPO source repo (read-only)
+        id: ospo_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.OSPO_WORKFLOW_APP_ID }}
+          private-key: ${{ secrets.OSPO_WORKFLOW_PRIVATE_KEY }}
+          owner: National-Node-Net
+          repositories: ospo-resources
+          permission-contents: read
+
+      - name: Checkout target repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          token: ${{ steps.target_token.outputs.token }}
+
+      - name: Checkout OSPO source repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: National-Node-Net/ospo-resources
+          path: ospo-resources
+          token: ${{ steps.ospo_token.outputs.token }}
+
+      - name: Checkout archetypes source repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: National-Node-Net/archetypes
+          path: archetypes
+
+      - name: Fetch Repository Metadata
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const { writeFileSync } = require('fs');
+
+            // Check specifically for 'develop' branch existence
+            let hasDevelopBranch = false;
+            try {
+              await github.rest.repos.getBranch({
+                owner,
+                repo,
+                branch: 'develop',
+              });
+              hasDevelopBranch = true;
+            } catch (error) {
+              if (error.status !== 404) {
+                 core.warning(`Error checking for develop branch: ${error.message}`);
+              }
+            }
+
+            const metadata = {
+              repository: {
+                defaultBranch: process.env.DEFAULT_BRANCH,
+                hasDevelopBranch: hasDevelopBranch
+              }
+            };
+
+            const rawMetadata = JSON.stringify(metadata, null, 2);
+
+            core.info('Content for repository-metadata.json:');
+            core.info(rawMetadata);
+
+            writeFileSync('repository-metadata.json', rawMetadata);
+            core.info('Generated repository-metadata.json for policy context.');
+
+      - name: Install Conftest
+        env:
+          FALLBACK_VERSION: '0.67.1'
+        run: |
+          set -euo pipefail
+
+          install_conftest() {
+            local version="$1"
+            local file_name="conftest_${version}_Linux_x86_64.deb"
+            curl --proto "=https" --fail -sSL "https://github.com/open-policy-agent/conftest/releases/download/v${version}/${file_name}" -o "${file_name}"
+            sudo dpkg -i "${file_name}"
+            rm -f "${file_name}"
+          }
+
+          LATEST_VERSION="$(curl --proto "=https" --fail -s "https://api.github.com/repos/open-policy-agent/conftest/releases/latest" | grep -Po '"tag_name": "v\K[0-9.]+' || true)"
+
+          if [[ -n "${LATEST_VERSION}" ]] && install_conftest "${LATEST_VERSION}"; then
+            echo "Installed latest Conftest version: ${LATEST_VERSION}"
+          else
+            echo "Failed to install latest Conftest. Falling back to version ${FALLBACK_VERSION}."
+            install_conftest "${FALLBACK_VERSION}"
+          fi
+
+      - name: Run Policy Checks
+        id: run_conftest
+        run: |
+          conftest test .github/dependabot.yml \
+            -p ospo-resources/tools/policy-as-code/policy \
+            --data repository-metadata.json \
+            --namespace github.dependabot \
+            --output json > policy-report.json || true
+
+      - name: Process Policy Results
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+             const { existsSync, readFileSync, writeFileSync } = require('fs');
+
+             let resultJson = [];
+             if (existsSync('policy-report.json')) {
+               try {
+                 const rawContent = readFileSync('policy-report.json', 'utf8');
+                 if (rawContent.trim()) {
+                    resultJson = JSON.parse(rawContent);
+                 }
+               } catch(e) {
+                 core.error(`Failed to parse policy-report.json: ${e.message}`);
+                 core.setFailed(`Failed to parse policy-report.json: ${e.message}`);
+                 return;
+               }
+             }
+
+             const results = resultJson.map(r => {
+               const failureReasons = (r.failures || []).map(f => f.msg);
+               return {
+                 path: r.filename,
+                 status: failureReasons.length > 0 ? 'failed' : 'passed',
+                 failureReasons: failureReasons,
+                 checks: {
+                   namespace: r.namespace,
+                   successes: r.successes
+                 }
+               };
+             });
+
+             const passed = results.filter((result) => result.status === 'passed').length;
+             const failed = results.length - passed;
+             const score = results.length > 0 ? Number((passed / results.length).toFixed(2)) : 0;
+
+             const prHead = context.payload.pull_request?.head;
+             const repoFullName = prHead?.repo?.full_name ?? process.env.GITHUB_REPOSITORY ?? 'unknown/unknown';
+             const commitSha = prHead?.sha ?? process.env.GITHUB_SHA ?? 'unknown';
+
+             const report = {
+               runMetadata: {
+                 timestamp: new Date().toISOString(),
+                 repo: repoFullName,
+                 commit: commitSha,
+                 checkType: 'policy',
+               },
+               files: results,
+               summary: {
+                 total: results.length,
+                 passed,
+                 failed,
+                 score,
+               },
+             };
+
+             const reportPath = 'policy-results.json';
+             writeFileSync(reportPath, JSON.stringify(report, null, 2));
+             core.info(`Wrote policy summary to ${reportPath}`);
+             
+             if (failed > 0) {
+               core.setFailed('Policy checks failed for one or more files.');
+             } else {
+               core.info('All policy checks passed.');
+             }
+
+      - name: Test for presence of OSS files and variation from templated content
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        if: success() || failure()
+        with:
+          script: |
+            const { existsSync, readFileSync, writeFileSync } = require('fs');
+
+            const checklistPath = 'ospo-resources/oss-checklist-files.txt';
+            const checklist = readFileSync(checklistPath, 'utf8')
+              .split('\n')
+              .map((line) => line.trim())
+              .filter((line) => line && !line.startsWith('#'));
+
+            const results = [];
+            const prHead = context.payload.pull_request?.head;
+            const repoFullName = prHead?.repo?.full_name ?? process.env.GITHUB_REPOSITORY ?? 'unknown/unknown';
+            const commitSha = prHead?.sha ?? process.env.GITHUB_SHA ?? 'unknown';
+
+            for (const relativePath of checklist) {
+              const record = {
+                path: relativePath,
+                status: 'passed',
+                checks: {
+                  exists: false,
+                  differsFromTemplate: null,
+                },
+                failureReasons: [],
+              };
+
+              const targetPath = relativePath;
+              const archetypePath = `archetypes/${relativePath}`;
+
+              const fileExists = existsSync(targetPath);
+              record.checks.exists = fileExists;
+
+              if (!fileExists) {
+                record.status = 'failed';
+                record.failureReasons.push('missing or misnamed');
+                core.info(`Missing or misnamed OSS file in target repository: ${targetPath}`);
+                results.push(record);
+                continue;
+              }
+
+              const targetContent = readFileSync(targetPath, 'utf8');
+
+              if (existsSync(archetypePath)) {
+                const archetypeContent = readFileSync(archetypePath, 'utf8');
+                const differsFromTemplate = targetContent !== archetypeContent;
+                record.checks.differsFromTemplate = differsFromTemplate;
+
+                if (!differsFromTemplate) {
+                  record.failureReasons.push('unchanged from archetype template');
+                  core.info(`OSS file unchanged from archetypes template: ${targetPath}`);
+                } else {
+                  core.info(`OSS file present and different from the archetypes template: ${targetPath}`);
+                }
+              } else {
+                record.checks.differsFromTemplate = null;
+                core.info(`Template file missing for ${relativePath}; skipping template comparison.`);
+              }
+
+              record.status = record.failureReasons.length > 0 ? 'failed' : 'passed';
+              results.push(record);
+            }
+
+            const passed = results.filter((result) => result.status === 'passed').length;
+            const failed = results.length - passed;
+            const score = results.length > 0 ? Number((passed / results.length).toFixed(2)) : 0;
+
+            const report = {
+              runMetadata: {
+                checklistFile: checklistPath,
+                timestamp: new Date().toISOString(),
+                repo: repoFullName,
+                commit: commitSha,
+                checkType: 'OSS',
+              },
+              files: results,
+              summary: {
+                total: results.length,
+                passed,
+                failed,
+                score,
+              },
+            };
+
+            const reportPath = 'oss-results.json';
+            writeFileSync(reportPath, JSON.stringify(report, null, 2));
+            core.info(`Wrote checklist summary to ${reportPath}`);
+
+            if (failed > 0) {
+              const failedFiles = results
+                .filter((result) => result.status === 'failed')
+                .map((result) => result.path);
+              core.setFailed(`The following files failed checks:\n${failedFiles.join('\n')}`);
+            } else {
+              core.info('All OSS files are present and have been updated from their original templated content.');
+            }
+
+      - name: Check GitHub template files are present
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        if: success() || failure()
+        with:
+          script: |
+            const { existsSync, writeFileSync  } = require('fs');
+
+            core.info('Checking for pull request and issue template files');
+
+            const filesToCheck = [
+              '.github/PULL_REQUEST_TEMPLATE.md',
+              '.github/ISSUE_TEMPLATE/bug_report.md',
+              '.github/ISSUE_TEMPLATE/feature_request.md',
+            ];
+
+            const results = filesToCheck.map((filePath) => {
+              const exists = existsSync(filePath);
+              return {
+                path: filePath,
+                status: exists ? 'passed' : 'failed',
+                checks: {
+                  exists,
+                  differsFromTemplate: null,
+                },
+                failureReasons: exists ? [] : ['missing or misnamed'],
+              };
+            });
+
+            const passed = results.filter((result) => result.status === 'passed').length;
+            const failed = results.length - passed;
+            const score = results.length > 0 ? Number((passed / results.length).toFixed(2)) : 0;
+
+            const prHead = context.payload.pull_request?.head;
+            const report = {
+              runMetadata: {
+                timestamp: new Date().toISOString(),
+                repo: prHead?.repo?.full_name ?? process.env.GITHUB_REPOSITORY ?? 'unknown/unknown',
+                commit: prHead?.sha ?? process.env.GITHUB_SHA ?? 'unknown',
+                checkType: 'template',
+              },
+              files: results,
+              summary: {
+                total: results.length,
+                passed,
+                failed,
+                score,
+              },
+            };
+
+            const reportPath = 'template-results.json';
+            writeFileSync(reportPath, JSON.stringify(report, null, 2));
+            core.info(`Wrote template checklist summary to ${reportPath}`);
+
+            if (failed > 0) {
+              const missingTemplates = results
+                .filter((result) => result.status === 'failed')
+                .map((result) => result.path);
+
+              core.info('');
+              core.info('Required GitHub template files were not found or did not match expected casing:');
+              missingTemplates.forEach((file) => core.info(`  - ${file}`));
+              core.info('');
+              core.info('These files help improve project collaboration and are considered best practice.');
+              core.info('These need to be included in repository contents to improve the developer and repository consumer experience.');
+              core.setFailed('Missing or misnamed GitHub template files.');
+            } else {
+              core.info('Required pull request and issue template files present.');
+            }
+
+      - name: Generate summary
+        id: summarise_results
+        if: always()
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const { existsSync, readFileSync } = require('fs');
+
+            const reportFiles = [
+              'oss-results.json',
+              'template-results.json',
+              'policy-results.json',
+            ];
+
+            const reports = reportFiles
+              .filter((reportPath) => {
+                const present = existsSync(reportPath);
+                if (!present) {
+                  core.info(`Summary step skipping missing report: ${reportPath}`);
+                }
+                return present;
+              })
+              .map((reportPath) => JSON.parse(readFileSync(reportPath, 'utf8')));
+
+            if (reports.length === 0) {
+              core.info('No report files found; skipping combined summary.');
+              core.setOutput('hasResults', 'false');
+              return;
+            }
+
+            const allResults = reports.flatMap((report) =>
+              report.files.map((file) => ({
+                ...file,
+                category: report.runMetadata?.checkType ?? 'unknown',
+                repo: report.runMetadata?.repo ?? process.env.GITHUB_REPOSITORY ?? 'unknown/unknown',
+                commit: report.runMetadata?.commit ?? process.env.GITHUB_SHA ?? 'unknown',
+              })),
+            );
+
+            const combinedTableMarkdown = [
+              '| 📄 File | ✅ Result | 🧾 Details |',
+              '| :--- | :---: | :--- |',
+              ...allResults.map((result) => {
+                const href = `https://github.com/${result.repo}/blob/${result.commit}/${result.path}`;
+                const details = result.failureReasons.length > 0
+                  ? result.failureReasons.join('; ')
+                  : 'Compliant';
+                const statusLabel = result.status === 'passed' ? '🟢 Pass' : '🔴 Fail';
+                return `| [${result.path}](${href}) | ${statusLabel} | ${details} |`;
+              }),
+            ].join('\n');
+
+            const total = allResults.length;
+            const passed = allResults.filter((result) => result.status === 'passed').length;
+            const failed = total - passed;
+            const score = total > 0 ? (passed / total) * 100 : 0;
+            const summary = { total, passed, failed, score };
+
+            const overallStatus = summary.failed === 0
+              ? '🎉 Overall status: PASS (all files compliant).'
+              : '⚠️ Overall status: FAIL (see table below for details).';
+
+            const summaryMarkdown = [
+              '| 📊 Total Files | 🟢 Passed | 🔴 Failed | 🧮 Score |',
+              '| ---: | ---: | ---: | ---: |',
+              `| ${summary.total} | ${summary.passed} | ${summary.failed} | ${summary.score.toFixed(0)}% |`
+            ].join('\n');
+
+            const prHead = context.payload.pull_request?.head;
+            const repoFullName = prHead?.repo?.full_name ?? process.env.GITHUB_REPOSITORY ?? 'unknown/unknown';
+            const fullSha = prHead?.sha ?? process.env.GITHUB_SHA ?? '';
+            const shortSha = fullSha?.slice(0, 7) ?? 'unknown';
+            const commitUrl = fullSha
+              ? `https://github.com/${repoFullName}/commit/${fullSha}`
+              : null;
+            const commitLine = commitUrl
+              ? `Results from commit [\`${shortSha}\`](${commitUrl}).`
+              : `Results from commit \`${shortSha}\`.`;
+
+            await core.summary
+              .addRaw('# OSS Check Results ⚙️\n', true)
+              .addRaw(`\n${combinedTableMarkdown}\n`, true)
+              .addRaw('\n# Summary 🏁\n', true)
+              .addRaw(`\n${overallStatus}\n`, true)
+              .addRaw(`\n${summaryMarkdown}\n`, true)
+              .addRaw(`\n${commitLine}\n`, true)
+              .write();
+
+            core.setOutput('hasResults', 'true');
+            core.setOutput('summaryTable', summaryMarkdown);
+
+            if (summary.failed > 0) {
+              core.setFailed('OSS checks detected one or more failing files.');
+            }
+
+      - name: Upload OSS result artifacts
+        if: ${{ steps.summarise_results.outputs.hasResults == 'true' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: oss-checks-${{ github.run_id }}
+          retention-days: 30
+          path: |
+            oss-results.json
+            template-results.json
+            policy-results.json
+
+  comment-on-results:
+    needs: oss-checks
+    if: >-
+      always() &&
+      github.event_name == 'pull_request' &&
+      needs.oss-checks.outputs.has-results == 'true'
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Comment with OSS summary
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          SUMMARY_TABLE: ${{ needs.oss-checks.outputs.summary-table }}
+          JOB_RESULT: ${{ needs.oss-checks.result }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const prNumber = context.payload.pull_request?.number;
+
+            if (!prNumber) {
+              core.info('No pull request context; skipping comment step.');
+              return;
+            }
+
+            const jobSummaryUrl = `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`;
+            const prHead = context.payload.pull_request?.head;
+            const headCommitSha = prHead?.sha ?? process.env.GITHUB_SHA ?? '';
+            const shortSha = headCommitSha ? headCommitSha.slice(0, 7) : 'unknown';
+            const runResult = process.env.JOB_RESULT?.toLowerCase() ?? '';
+            const isFailure = runResult === 'failure';
+
+            const marker = '<!-- oss-checks-comment -->';
+            const heading = isFailure
+              ? '## ⚠️ OSS Checks Failed'
+              : '## ✅ OSS Checks Passed';
+            const narration = isFailure
+              ? 'One or more OSS checks failed in this run.'
+              : 'All tracked OSS checks passed in this run.';
+
+            const bodySections = [
+              heading,
+              narration,
+              process.env.SUMMARY_TABLE,
+              `Results from commit ${shortSha}, view the full [job summary↗️](${jobSummaryUrl}) for detailed results.`
+            ];
+
+            const existingComments = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner,
+                repo,
+                issue_number: prNumber,
+                per_page: 100,
+              },
+            );
+
+            const previous = existingComments.find((comment) =>
+              comment.body?.includes(marker),
+            );
+
+            if(previous) {
+              bodySections.push(':recycle: This comment has been updated with latest results.');
+            }
+
+            const body = `${marker}\n${bodySections.join('\n\n')}\n${marker}`;
+
+            if (previous) {
+              core.info(`Updating existing OSS summary comment (${previous.id}).`);
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: previous.id,
+                body,
+              });
+            } else {
+              core.info('Creating new OSS summary comment.');
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: prNumber,
+                body,
+              });
+            }

--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -2,7 +2,7 @@
 # © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
 # This workflow is triggered when a pull request is merged into the main branch
-# from a release/* branch. It extracts the release version from the source branch,
+# from a release/* or hotfix/* branch. It extracts the release version from the source branch,
 # generates a Software Bill of Materials (SBOM) using the GitHub API,
 # creates a Git tag with the version, and publishes a GitHub release including the SBOM file.
 
@@ -15,12 +15,18 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   versioning:
-    if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/')
+    if: |
+      github.event.pull_request.merged == true &&
+      (startsWith(github.head_ref, 'release/') || startsWith(github.head_ref, 'hotfix/'))
+    permissions:
+      contents: read
+
     name: Extract Release Version
     runs-on: ubuntu-latest
     outputs:
@@ -28,8 +34,10 @@ jobs:
     steps:
       - name: Extract Version from Source Branch Name
         id: extract_version
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         run: |
-          SOURCE_BRANCH="${{ github.head_ref }}"
+          SOURCE_BRANCH="$HEAD_REF"
           VERSION=$(echo "$SOURCE_BRANCH" | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+')
 
           if [ -z "$VERSION" ]; then
@@ -41,71 +49,93 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Validate Version Format (Semantic Versioning)
+        env:
+          VERSION: ${{ env.VERSION }}
         run: |
-          if [[ ! "${{ env.VERSION }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Error: Invalid version format found. Expected semantic version in release branch name (e.g., release/0.9.0)"
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: Invalid version format found. Expected semantic version in release or hotfix branch name (e.g., release/0.9.0 or hotfix/0.9.1)"
             exit 1
           fi
 
       - name: Print Tag Version
+        id: print_tag
+        env:
+          EXTRACTED_VERSION: ${{ steps.extract_version.outputs.version }}
         run: |
-          echo "Identified release semantic version: ${{ steps.extract_version.outputs.version }}"
+          echo "Identified release semantic version: $EXTRACTED_VERSION"
 
   generate-sbom:
+    permissions:
+      contents: read
+
     name: Generate SPDX SBOM
     runs-on: ubuntu-latest
     needs: [versioning]
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Generate SPDX SBOM
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
         run: |
           # Call GitHub API to generate SBOM
           api_response=$(curl -sSL \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            "$GITHUB_API_URL/repos/${{ github.repository }}/dependency-graph/sbom")
+            "$GITHUB_API_URL/repos/$REPO/dependency-graph/sbom")
 
           # Extract nested "sbom" object into a valid SPDX file
           echo "$api_response" | jq '.sbom' > sbom.spdx.json
 
       - name: Upload SBOM Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sbom
           path: sbom.spdx.json
 
   create-git-tag:
+    permissions:
+      contents: write
+
     name: Create Git Tag
     needs: [versioning, generate-sbom]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
       - name: Create Git Tag
-        uses: rickstaa/action-create-tag@v1
+        uses: rickstaa/action-create-tag@a1c7777fcb2fee4f19b0f283ba888afa11678b72 # v1.7.2
         with:
           tag: "v${{ needs.versioning.outputs.version }}"
           message: "Release v${{ needs.versioning.outputs.version }}"
           force_push_tag: true
+          # Tag the HEAD commit from the merged release branch not the merge commit to
+          # ensure the tag points to the correct source code state for the release.
+          # This ensures that the release tag is also visible on any branch which does
+          # not contain the merge commit such as develop.
+          commit_sha: ${{ github.event.pull_request.head.sha }}
 
   create-git-release:
+    permissions:
+      contents: write
+
     name: Create GitHub Release
     needs: [versioning, generate-sbom, create-git-tag]
     runs-on: ubuntu-latest
     steps:
       - name: Download SBOM Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: sbom
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:
           tag_name: "v${{ needs.versioning.outputs.version }}"
           name: "Release v${{ needs.versioning.outputs.version }}"

--- a/ACKNOWLEDGEMENTS.md
+++ b/ACKNOWLEDGEMENTS.md
@@ -14,7 +14,7 @@ Over time, the following organisations have provided technical expertise, develo
 We are grateful for the collaboration that has helped shape this repository.
 
 ## Individual contributions
-For a list of individual contributors who have made direct commits to this repository, see GitHub’s auto-generated contributor insights: [Contributors](https://github.com/National-Digital-Twin/secure-agent-graph/graphs/contributors).
+For a list of individual contributors who have made direct commits to this repository, see GitHub’s auto-generated contributor insights: [Contributors](https://github.com/National-Node-Net/secure-agent-graph/graphs/contributors).
 
 ---  
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ This project follows **Semantic Versioning (SemVer)** ([semver.org](https://semv
 
 ---
 
-## [Unreleased]
+## 0.90.1 – 2026-07-16
 
 ### Added
 - Added documentation and docker compose for running smoke tests.
@@ -27,6 +27,7 @@ This project follows **Semantic Versioning (SemVer)** ([semver.org](https://semv
 - Addressed sonarqube security blockers.
 
 ### Changed
+- Alignment of GitHub actions to new organisation.
 - Placeholder for changes to existing functionality.
 
 ---
@@ -46,17 +47,6 @@ Since this release is **pre-1.0.0**, changes may still occur that are **not full
 #### Known Limitations
 - Some components are subject to change before `1.0.0`.
 - APIs may evolve based on partner feedback and internal testing.
-
----
-
-## [0.90.1] – YYYY-MM-DD
-
-### Fixed
-- Security patch addressing [issue].
-- Minor bug fix in [module].
-
----
-
 ## [0.91.0] – YYYY-MM-DD
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ NDTP follows an **open-source governance model** where all code is **publicly av
 partners**. Contributions from the general public are not currently accepted, but **feedback, issue reporting, and documentation suggestions are encouraged**.  
 
 If you want to see which suppliers and organisations have contributed to this repository in the past, refer to [ACKNOWLEDGEMENTS.md](ACKNOWLEDGEMENTS.md) and the GitHub
-contributor insights page at [Contributors](https://github.com/National-Digital-Twin/secure-agent-graph/graphs/contributors).
+contributor insights page at [Contributors](https://github.com/National-Node-Net/secure-agent-graph/graphs/contributors).
 
 ---
 ## How You Can Contribute
@@ -34,7 +34,7 @@ For details on repository maintainers and how to contact them, refer to [MAINTAI
 
 If you encounter a bug, error, or inconsistency, please follow these steps:
 
-1. Check for an existing issue under [Issues](https://github.com/National-Digital-Twin/secure-agent-graph/issues).
+1. Check for an existing issue under [Issues](https://github.com/National-Node-Net/secure-agent-graph/issues).
 2. Open a new issue if no one has reported it yet. Use one of the provided issue templates.
 3. Provide a clear, detailed description of the issue, including steps to reproduce it if applicable.
 4. Label the issue appropriately (bug, documentation, enhancement, etc.).  
@@ -61,7 +61,7 @@ We prioritise documentation updates based on user impact and alignment with prog
 - **Development is led by approved suppliers and partners** who have been engaged through a formal process.
 - **We welcome feedback and ideas**, but implementation is subject to programme priorities. 
 
-To see what we’re working on, check out our [Project Roadmap](https://github.com/National-Digital-Twin/secure-agent-graph/projects). If no roadmap is currently available, please note that it is being actively developed and will be published in due course.
+To see what we’re working on, check out our [Project Roadmap](https://github.com/National-Node-Net/secure-agent-graph/projects). If no roadmap is currently available, please note that it is being actively developed and will be published in due course.
 
 ---
 ## Branching Strategy

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -7,7 +7,7 @@
 Secure Agent Graph (SAG) provides [SPARQL](https://www.w3.org/TR/sparql-overview/) access using the [SPARQL
 protocol](https://www.w3.org/TR/sparql-protocol/) and [SPARQL Graph Store
 Protocol](https://www.w3.org/TR/sparql-graph-store-protocol/) to RDF data with [ABAC data
-security](https://github.com/National-Digital-Twin/rdf-abac/blob/main/docs/abac.md).
+security](https://github.com/National-Node-Net/rdf-abac/blob/main/docs/abac.md).
 
 ## Starting installation
 1. Run:
@@ -61,7 +61,7 @@ You can find further example configurations later under [Try It Out](#try-it-out
 The following environment variables can be used to control Secure Agent Graph:
 
 ### `USER_ATTRIBUTES_URL`
-This is the network location of [user attribute server](https://github.com/National-Digital-Twin/ianode-access) which also
+This is the network location of [user attribute server](https://github.com/National-Node-Net/ianode-access) which also
 includes the hierarchies management.
 
 The URL value is a template including `{user}`. Example: `http://some-host/users/lookup/{user}`

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository contributes to the development of **secure, scalable, and intero
 
 This repository is one of several open-source components that underpin NDTP’s **Integration Architecture (IA)**—a framework designed to allow organisations to manage and exchange data securely while maintaining control over their own information. The IA is actively deployed and tested across multiple sectors, ensuring its adaptability and alignment with real-world needs. 
 
-For a complete overview of the Integration Architecture (IA) project, please see the [Integration Architecture Documentation](https://github.com/National-Digital-Twin/integration-architecture-documentation).
+For a complete overview of the Integration Architecture (IA) project, please see the [Integration Architecture Documentation](https://github.com/National-Node-Net/integration-architecture-documentation).
 
 ## Prerequisites  
 Before using this repository, ensure you have the following dependencies installed:  
@@ -31,7 +31,7 @@ Follow these steps to get started quickly with this repository. For detailed ins
 
 ### 1. Download and Build  
 ```sh  
-git clone https://github.com/National-Digital-Twin/secure-agent-graph.git
+git clone https://github.com/National-Node-Net/secure-agent-graph.git
 cd [secure-agent-graph]  
 ```
 ### 2. Run Build Version  
@@ -52,12 +52,12 @@ For steps to remove this repository and its dependencies, see [UNINSTALL.md](UNI
 ## Features  
 - **Key functionality** 
     - Supports secure and RDF (Resource Description Framework) data-sharing.
-    - Implements [ABAC (Attribute-Based Access Control)](https://github.com/National-Digital-Twin/rdf-abac/blob/main/docs/abac.md) data security.
+    - Implements [ABAC (Attribute-Based Access Control)](https://github.com/National-Node-Net/rdf-abac/blob/main/docs/abac.md) data security.
 - **Key integrations** 
     - Provides SPARQL access using the SPARQL protocol and SPARQL Graph Store Protocol.
     - Integrates with Apache Jena Fuseki server.
     - Includes Fuseki-Kafka bridge for Kafka integration.
-    - Offers [GraphQL]((https://github.com/National-Digital-Twin/graphql-jena/blob/main/docs/index.md)) API interfaces.
+    - Offers [GraphQL]((https://github.com/National-Node-Net/graphql-jena/blob/main/docs/index.md)) API interfaces.
 - **Scalability & performance** 
     - Optimised for high-throughput environments.
     - Supports in-memory datasets for fast data access.

--- a/docker-compose/docker-compose-fuseki.yaml
+++ b/docker-compose/docker-compose-fuseki.yaml
@@ -26,4 +26,4 @@ services:
       - graph
     environment:
       - FUSEKI_CONFIG=secure-agent-graph-config.ttl
-    image: ghcr.io/national-digital-twin/secure-agent-graph:0.90.0
+    image: ghcr.io/national-node-net/secure-agent-graph:0.90.0

--- a/docs/configuration-secure-agent-graph.md
+++ b/docs/configuration-secure-agent-graph.md
@@ -7,8 +7,8 @@ Secure Agent Graph is an
 [Apache Jena Fuseki server](https://jena.apache.org/documentation/fuseki2/)
 with additional features:
 
-* [ABAC datasets](https://github.com/National-Digital-Twin/rdf-abac/blob/main/docs/abac.md)
-* [GraphQL](https://github.com/National-Digital-Twin/graphql-jena/blob/main/docs/index.md)
+* [ABAC datasets](https://github.com/National-Node-Net/rdf-abac/blob/main/docs/abac.md)
+* [GraphQL](https://github.com/National-Node-Net/graphql-jena/blob/main/docs/index.md)
 * [OpenTelemetry](./opentelemetry.md) support
 
 Secure Agent Graph is configured using a [Fuseki configuration

--- a/pom.xml
+++ b/pom.xml
@@ -34,12 +34,12 @@
 
   <name>IANode Secure Agent Graph - Parent</name>
   <description>IANode Secure Agent Graph</description>
-  <url>https://github.com/National-Digital-Twin/secure-agent-graph</url>
+  <url>https://github.com/National-Node-Net/secure-agent-graph</url>
 
   <scm>
-    <connection>scm:git:git@github.com:National-Digital-Twin/secure-agent-graph</connection>
-    <developerConnection>scm:git:git@github.com:National-Digital-Twin/secure-agent-graph</developerConnection>
-    <url>https://github.com/National-Digital-Twin/secure-agent-graph</url>
+    <connection>scm:git:git@github.com:National-Node-Net/secure-agent-graph</connection>
+    <developerConnection>scm:git:git@github.com:National-Node-Net/secure-agent-graph</developerConnection>
+    <url>https://github.com/National-Node-Net/secure-agent-graph</url>
     <tag>HEAD</tag>
   </scm>
 
@@ -387,7 +387,7 @@
           <version>${plugin.deploy}</version>
           <configuration>
             <repositoryId>github</repositoryId>
-            <url>https://maven.pkg.github.com/National-Digital-Twin/secure-agent-graph</url>
+            <url>https://maven.pkg.github.com/National-Node-Net/secure-agent-graph</url>
           </configuration>
         </plugin>
 
@@ -562,7 +562,7 @@
   <repositories>
     <repository>
       <id>github</id>
-      <url>https://maven.pkg.github.com/National-Digital-Twin/*</url>
+      <url>https://maven.pkg.github.com/National-Node-Net/*</url>
       <releases>
         <enabled>true</enabled>
       </releases>
@@ -575,12 +575,12 @@
     <snapshotRepository>
       <id>github</id>
       <name>GitHub Packages</name>
-      <url>https://maven.pkg.github.com/National-Digital-Twin/secure-agent-graph</url>
+      <url>https://maven.pkg.github.com/National-Node-Net/secure-agent-graph</url>
     </snapshotRepository>
     <repository>
       <id>github</id>
       <name>GitHub Packages</name>
-      <url>https://maven.pkg.github.com/National-Digital-Twin/secure-agent-graph</url>
+      <url>https://maven.pkg.github.com/National-Node-Net/secure-agent-graph</url>
     </repository>
   </distributionManagement>
 

--- a/sag-docker/Test/docker-compose.yaml
+++ b/sag-docker/Test/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
       - "9229:9229"
 
   smoke-test-secure-agent-graph-auth:
-    image: ghcr.io/national-digital-twin/secure-agent-graph:0.90.0
+    image: ghcr.io/national-node-net/secure-agent-graph:0.90.0
     depends_on:
       - smoke-test-cognito-local
     ports:
@@ -34,7 +34,7 @@ services:
     command: "--config /fuseki/config/dev-server-graphql.ttl -port 3031"
 
   smoke-test-secure-agent-graph-no-auth:
-    image: ghcr.io/national-digital-twin/secure-agent-graph:0.90.0
+    image: ghcr.io/national-node-net/secure-agent-graph:0.90.0
     ports:
       - "3030:3030"
     environment:


### PR DESCRIPTION
Alignment of GitHub actions to the new organisation (National-Digital-Twin -> National-Node-Net), plus dependent secret renames and CHANGELOG entry.