### PR TITLE
fix(ospo): correct dependabot.yml schema

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,8 +24,8 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "16:00"
-      commit-message:
-        prefix: "chore(deps)"
+    commit-message:
+      prefix: "chore(deps)"
     target-branch: develop
     groups:
       sorbet:


### PR DESCRIPTION
Dependabot reported: `The property '#/updates/0/schedule' contains additional properties [\"commit-message\"] outside of the schema when none are allowed`. The bundler entry's `commit-message` key was incorrectly nested inside the `schedule:` block instead of at the update-entry level. Moved it out to fix the schema validation error.